### PR TITLE
Feat/eventbuffer

### DIFF
--- a/_example/migrations/1_base.up.sql
+++ b/_example/migrations/1_base.up.sql
@@ -6,12 +6,14 @@ CREATE TABLE users(
     active BOOLEAN NOT NULL DEFAULT false,
     last_signed_in TIMESTAMP DEFAULT null,
     created_at TIMESTAMP NOT NULL DEFAULT now(),
-    updated_at TIMESTAMP NOT NULL DEFAULT now()
+    updated_at TIMESTAMP NOT NULL DEFAULT now(),
+    version INT NOT NULL
 );
 
 CREATE TABLE roles(
     ID VARCHAR(128) NOT NULL PRIMARY KEY,
-    label varchar(128) NOT NULL
+    label varchar(128) NOT NULL,
+    version INT NOT NULL
 );
 
 CREATE TABLE scopes(

--- a/_example/migrations/2_initial-data.up.sql
+++ b/_example/migrations/2_initial-data.up.sql
@@ -1,8 +1,8 @@
-INSERT INTO users (id, name, email, hash, active) VALUES ('e67347d6-9a19-4bf0-83ed-fd62d2a53906', 'Gabriel Carpreau', 'me@gabrielcarpreau.com', '$2a$10$iRrRnyVD0EMLPWfsjieAAuFG1yGm31WeXQB1NVX2AJ13txwdJKUlG', true);
+INSERT INTO users (id, name, email, hash, active, version) VALUES ('e67347d6-9a19-4bf0-83ed-fd62d2a53906', 'Gabriel Carpreau', 'me@gabrielcarpreau.com', '$2a$10$iRrRnyVD0EMLPWfsjieAAuFG1yGm31WeXQB1NVX2AJ13txwdJKUlG', true, 1);
 
 INSERT INTO scopes (name) VALUES ('self:read'), ('self:write'), ('users:read'), ('users:write'), ('roles:read'), ('roles:write');
 
-INSERT INTO roles (ID, label) VALUES ('admin', 'Admin'), ('user', 'User');
+INSERT INTO roles (ID, label, version) VALUES ('admin', 'Admin', 1), ('user', 'User', 1);
 
 INSERT INTO user_roles (user_id, role_id) VALUES ('e67347d6-9a19-4bf0-83ed-fd62d2a53906', 'user'), ('e67347d6-9a19-4bf0-83ed-fd62d2a53906', 'admin');
 

--- a/_example/users/commands/create_role.go
+++ b/_example/users/commands/create_role.go
@@ -49,11 +49,12 @@ func (h *CreateRoleHandler) Execute(ctx context.Context, c bus.Command) (res bus
 	role := entities.CreateRole(cmd.Name)
 	role = role.ApplyScopes(cmd.Scopes...)
 
+	events := role.Commit()
 	err := h.roles.Persist(role)
 	switch err {
 	case nil:
 		res = bus.CommandResponse{ID: role.ID.String()}
-		msgs = append(msgs, role.Release()...)
+		msgs = append(msgs, events...)
 		return
 	default:
 		res = bus.CommandResponse{Error: err}

--- a/_example/users/commands/register.go
+++ b/_example/users/commands/register.go
@@ -94,11 +94,12 @@ func (h RegisterHandler) Execute(ctx context.Context, c bus.Command) (res bus.Co
 	user = user.ChangeName(cmd.Name)
 	user = user.Grant(userRole)
 
+	events := user.Commit()
 	err = h.users.Persist(user)
 	switch err {
 	case nil:
 		res = bus.CommandResponse{ID: user.ID.String()}
-		msgs = append(msgs, user.Release()...)
+		msgs = append(msgs, events...)
 		return
 	case errs.UniqueEntityExists:
 		res = bus.CommandResponse{Error: ErrUserExists}

--- a/_example/users/commands/update_role.go
+++ b/_example/users/commands/update_role.go
@@ -69,11 +69,12 @@ func (h UpdateRoleHandler) Execute(ctx context.Context, c bus.Command) (res bus.
 		role = role.DropScopes().ApplyScopes(*cmd.Scopes...)
 	}
 
+	events := role.Commit()
 	err = h.roles.Persist(role)
 	switch err {
 	case nil:
 		res.ID = role.ID.String()
-		msgs = role.Release()
+		msgs = events
 		return
 	default:
 		res.Error = err

--- a/_example/users/db/db_role_repository.go
+++ b/_example/users/db/db_role_repository.go
@@ -14,6 +14,7 @@ func fromRole(role entities.Role) dbRole {
 		ID:     role.ID.String(),
 		Label:  role.Label,
 		Scopes: scopes,
+		Version: role.CurrentVersion(),
 	}
 }
 
@@ -31,6 +32,7 @@ func scopes(roles ...entities.Role) []dbScope {
 type dbRole struct {
 	ID    string `gorm:"primaryKey"`
 	Label string
+	Version int64
 
 	Scopes []dbScope `gorm:"many2many:role_scopes;joinForeignKey:role_id;joinReferences:scope_id"`
 }
@@ -47,6 +49,7 @@ func (r dbRole) Role() entities.Role {
 	for _, s := range r.Scopes {
 		role = role.ApplyScopes(s.Name)
 	}
+	role.ForceVersion(r.Version)
 	return role
 }
 

--- a/_example/users/db/db_user_repository.go
+++ b/_example/users/db/db_user_repository.go
@@ -35,6 +35,7 @@ func fromUser(u entities.User) dbUser {
 		LastSignedIn: last,
 		CreatedAt:    u.CreatedAt,
 		UpdatedAt:    u.UpdatedAt,
+		Version: u.CurrentVersion(),
 	}
 }
 
@@ -57,6 +58,7 @@ type dbUser struct {
 	LastSignedIn sql.NullTime
 	CreatedAt    time.Time
 	UpdatedAt    time.Time
+	Version		 int64
 }
 
 func (d dbUser) TableName() string {
@@ -76,7 +78,7 @@ func (d dbUser) User() entities.User {
 		time = nil
 	}
 
-	return entities.User{
+	u := entities.User{
 		ID:           d.ID,
 		Name:         d.Name,
 		Email:        email,
@@ -86,8 +88,10 @@ func (d dbUser) User() entities.User {
 		LastSignedIn: time,
 		CreatedAt:    d.CreatedAt,
 		UpdatedAt:    d.UpdatedAt,
-		EventQueue:   bus.NewEventQueue(d.ID),
+		EventBuffer:   bus.NewEventBuffer(d.ID),
 	}
+	u.ForceVersion(d.Version)
+	return u
 }
 
 func NewDBUserRepository(db *gorm.DB) *DBUserRepository {

--- a/_example/users/entities/role.go
+++ b/_example/users/entities/role.go
@@ -40,7 +40,7 @@ func BuildRole(ID string, Label string) Role {
 		ID:         i,
 		Label:      Label,
 		scopes:     make(map[string]Scope),
-		EventQueue: bus.NewEventQueue(i),
+		EventBuffer: bus.NewEventBuffer(i),
 	}
 	return r
 }
@@ -55,9 +55,9 @@ func CreateRole(label string) Role {
 		ID:         id,
 		Label:      label,
 		scopes:     make(map[string]Scope),
-		EventQueue: bus.NewEventQueue(id),
+		EventBuffer: bus.NewEventBuffer(id),
 	}
-	r.Publish(&RoleCreated{Payload: r})
+	r.Buffer(true, &RoleCreated{Payload: r})
 	return r
 }
 
@@ -68,7 +68,7 @@ type Role struct {
 
 	scopes map[string]Scope
 
-	bus.EventQueue `json:"-"`
+	bus.EventBuffer `json:"version"`
 }
 
 // Scopes returns the role's scopes
@@ -95,7 +95,7 @@ func (r Role) ApplyScopes(scopes ...string) Role {
 	for _, scope := range scopes {
 		s := Scope{scope}
 		r.scopes[scope] = s
-		r.Publish(&RoleScopeApplied{Payload: s})
+		r.Buffer(true, &RoleScopeApplied{Payload: s})
 	}
 	return r
 }

--- a/_example/users/entities/role_test.go
+++ b/_example/users/entities/role_test.go
@@ -13,7 +13,7 @@ func TestRole_Scopes(t *testing.T) {
 	assert.Contains(t, role.Scopes(), entities.Scope{"access:user"})
 	assert.Contains(t, role.Scopes(), entities.Scope{"payments:write"})
 	assert.NotContains(t, role.Scopes(), entities.Scope{"users:write"})
-	events := role.Release()
+	events := role.Commit()
 	assert.Len(t, events, 3)
 	created := events[0].(*entities.RoleCreated)
 	assert.Equal(t, "user", created.Owner)

--- a/_example/users/entities/user_test.go
+++ b/_example/users/entities/user_test.go
@@ -13,7 +13,7 @@ func TestRegister(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, user.Email.String(), "gabriel.carpreau@gmail.com")
-	events := user.Release()
+	events := user.Commit()
 	assert.Len(t, events, 1)
 	assert.IsType(t, &entities.UserCreated{}, events[0])
 	assert.Equal(t, user.ID.String(), events[0].(*entities.UserCreated).Owner)
@@ -64,14 +64,14 @@ func TestGetUserScopes(t *testing.T) {
 
 func TestGrantRole(t *testing.T) {
 	u, _ := entities.Register("gabriel@gmail.com", "password123")
-	u.Release()
+	u.Commit()
 	r := entities.CreateRole("Ambassador")
 
 	u = u.Grant(r)
 
 	assert.Len(t, u.RoleIDs, 1)
 	assert.Contains(t, u.RoleIDs, entities.NewRoleID("ambassador"))
-	events := u.Release()
+	events := u.Commit()
 	assert.Len(t, events, 1)
 	assert.IsType(t, &entities.UserGrantedRole{}, events[0])
 }
@@ -95,12 +95,12 @@ func TestRevokeAll(t *testing.T) {
 	admin := entities.CreateRole("Admin")
 	u = u.Grant(r).Grant(admin)
 	assert.Len(t, u.RoleIDs, 2)
-	u.Release()
+	u.Commit()
 
 	u = u.Revoke()
 
 	assert.Len(t, u.RoleIDs, 0)
-	events := u.Release()
+	events := u.Commit()
 	assert.Len(t, events, 1)
 	assert.IsType(t, &entities.UserRevokedAllRoles{}, events[0])
 	event := events[0].(*entities.UserRevokedAllRoles)
@@ -113,13 +113,13 @@ func TestRevokeOne(t *testing.T) {
 	admin := entities.CreateRole("Admin")
 	u = u.Grant(admin).Grant(r)
 	assert.Len(t, u.RoleIDs, 2)
-	u.Release()
+	u.Commit()
 
 	u = u.Revoke(admin)
 
 	assert.Len(t, u.RoleIDs, 1)
 	assert.True(t, u.RoleIDs[0].Equals(r.ID))
-	events := u.Release()
+	events := u.Commit()
 	assert.Len(t, events, 1)
 	assert.IsType(t, &entities.UserRevokedRole{}, events[0])
 }

--- a/bus/events_test.go
+++ b/bus/events_test.go
@@ -1,11 +1,14 @@
 package bus_test
 
 import (
-	"github.com/GabrielCarpr/cqrs/bus"
+	"errors"
 	"testing"
+
+	"github.com/GabrielCarpr/cqrs/bus"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type TestEvent struct {
@@ -17,18 +20,121 @@ func (TestEvent) Event() string {
 	return "event.test"
 }
 
-func TestEventQueue(t *testing.T) {
+func TestEventBufferCommits(t *testing.T) {
 	owner := uuid.New()
-	queue := bus.NewEventQueue(owner)
+	queue := bus.NewEventBuffer(owner)
 
 	e := &TestEvent{Payload: "Hi"}
 	e2 := &TestEvent{Payload: "Bye"}
-	queue.Publish(e, e2)
+	queue.Buffer(true, e, e2)
 
-	events := queue.Release()
+	events := queue.Commit()
 	assert.Len(t, events, 2)
-	events2 := queue.Release()
-	assert.Len(t, events2, 0)
+	assert.Len(t, queue.Events(), 0)
 	event := events[0].(*TestEvent)
 	assert.Equal(t, owner.String(), event.Owner)
+}
+
+func TestEventBufferVersions(t *testing.T) {
+	queue := bus.NewEventBuffer(uuid.New())
+	require.Equal(t, int64(0), queue.Version)
+
+	e := &TestEvent{Payload: "Hi"}
+	queue.Buffer(false, e)
+	require.Equal(t, int64(1), queue.Version)
+	require.Equal(t, int64(1), queue.PendingVersion())
+
+	queue.Buffer(true, e)
+	require.Equal(t, int64(1), queue.Version)
+	require.Equal(t, int64(2), queue.PendingVersion())
+
+	msgs := queue.Commit()
+	require.Len(t, msgs, 1)
+	require.Equal(t, int64(2), queue.Version)
+	require.Equal(t, int64(2), queue.PendingVersion())
+	require.Equal(t, msgs[0], e)
+}
+
+/*
+Integration test
+*/
+
+type testNameChanged struct {
+	bus.EventType
+
+	Name string
+}
+
+func (testNameChanged) Event() string {
+	return "test.name.changed"
+}
+
+func newTestEntity() testEntity {
+	ID := uuid.New()
+	e := testEntity{
+		ID:          ID,
+		EventBuffer: bus.NewEventBuffer(ID),
+	}
+	return e
+}
+
+type testEntity struct {
+	ID   uuid.UUID
+	Name string
+
+	bus.EventBuffer
+}
+
+func (e *testEntity) ApplyChange(new bool, events ...bus.Event) {
+	for _, event := range events {
+		switch event := event.(type) {
+		case *testNameChanged:
+			e.Name = event.Name
+		}
+		e.Buffer(new, event)
+	}
+}
+
+func (e testEntity) GiveName(name string) (testEntity, error) {
+	if e.Name != "" {
+		return e, errors.New("Already has a name")
+	}
+
+	e.ApplyChange(true, &testNameChanged{Name: name})
+
+	return e, nil
+}
+
+func TestApplyChange(t *testing.T) {
+	entity := newTestEntity()
+
+	entity, err := entity.GiveName("Gabriel")
+	require.Nil(t, err)
+	require.Equal(t, "Gabriel", entity.Name)
+	require.Equal(t, int64(0), entity.Version)
+	require.Equal(t, int64(1), entity.PendingVersion())
+
+	entity.Commit()
+
+	require.Equal(t, int64(1), entity.CurrentVersion())
+}
+
+func TestLoadFromEvents(t *testing.T) {
+	events := []bus.Event{&testNameChanged{Name: "Harry Potter"}}
+	entity := newTestEntity()
+
+	entity.ApplyChange(false, events...)
+
+	require.Equal(t, int64(1), entity.Version)
+	require.Equal(t, int64(1), entity.PendingVersion())
+}
+
+func TestLoadFromData(t *testing.T) {
+	entity := newTestEntity()
+	entity.Name = "Harry Potter"
+	entity.ForceVersion(3)
+
+	require.Equal(t, int64(3), entity.Version)
+	require.Equal(t, "Harry Potter", entity.Name)
+	require.Equal(t, int64(3), entity.PendingVersion())
 }

--- a/gen/templates/init/migrations/1_base.up.sql
+++ b/gen/templates/init/migrations/1_base.up.sql
@@ -6,12 +6,14 @@ CREATE TABLE users(
     active BOOLEAN NOT NULL DEFAULT false,
     last_signed_in TIMESTAMP DEFAULT null,
     created_at TIMESTAMP NOT NULL DEFAULT now(),
-    updated_at TIMESTAMP NOT NULL DEFAULT now()
+    updated_at TIMESTAMP NOT NULL DEFAULT now(),
+    version INT NOT NULL
 );
 
 CREATE TABLE roles(
     ID VARCHAR(128) NOT NULL PRIMARY KEY,
-    label varchar(128) NOT NULL
+    label varchar(128) NOT NULL,
+    version INT NOT NULL
 );
 
 CREATE TABLE scopes(

--- a/gen/templates/init/migrations/2_initial-data.up.sql
+++ b/gen/templates/init/migrations/2_initial-data.up.sql
@@ -1,8 +1,8 @@
-INSERT INTO users (id, name, email, hash, active) VALUES ('e67347d6-9a19-4bf0-83ed-fd62d2a53906', 'Gabriel Carpreau', 'me@gabrielcarpreau.com', '$2a$10$iRrRnyVD0EMLPWfsjieAAuFG1yGm31WeXQB1NVX2AJ13txwdJKUlG', true);
+INSERT INTO users (id, name, email, hash, active, version) VALUES ('e67347d6-9a19-4bf0-83ed-fd62d2a53906', 'Gabriel Carpreau', 'me@gabrielcarpreau.com', '$2a$10$iRrRnyVD0EMLPWfsjieAAuFG1yGm31WeXQB1NVX2AJ13txwdJKUlG', true, 1);
 
 INSERT INTO scopes (name) VALUES ('self:read'), ('self:write'), ('users:read'), ('users:write'), ('roles:read'), ('roles:write');
 
-INSERT INTO roles (ID, label) VALUES ('admin', 'Admin'), ('user', 'User');
+INSERT INTO roles (ID, label, version) VALUES ('admin', 'Admin', 1), ('user', 'User', 1);
 
 INSERT INTO user_roles (user_id, role_id) VALUES ('e67347d6-9a19-4bf0-83ed-fd62d2a53906', 'user'), ('e67347d6-9a19-4bf0-83ed-fd62d2a53906', 'admin');
 

--- a/gen/templates/init/users/commands/create_role.go.tmpl
+++ b/gen/templates/init/users/commands/create_role.go.tmpl
@@ -49,11 +49,12 @@ func (h *CreateRoleHandler) Execute(ctx context.Context, c bus.Command) (res bus
 	role := entities.CreateRole(cmd.Name)
 	role = role.ApplyScopes(cmd.Scopes...)
 
+	events := role.Commit()
 	err := h.roles.Persist(role)
 	switch err {
 	case nil:
 		res = bus.CommandResponse{ID: role.ID.String()}
-		msgs = append(msgs, role.Release()...)
+		msgs = append(msgs, events...)
 		return
 	default:
 		res = bus.CommandResponse{Error: err}

--- a/gen/templates/init/users/commands/register.go.tmpl
+++ b/gen/templates/init/users/commands/register.go.tmpl
@@ -94,11 +94,12 @@ func (h RegisterHandler) Execute(ctx context.Context, c bus.Command) (res bus.Co
 	user = user.ChangeName(cmd.Name)
 	user = user.Grant(userRole)
 
+	events := user.Commit()
 	err = h.users.Persist(user)
 	switch err {
 	case nil:
 		res = bus.CommandResponse{ID: user.ID.String()}
-		msgs = append(msgs, user.Release()...)
+		msgs = append(msgs, events...)
 		return
 	case errs.UniqueEntityExists:
 		res = bus.CommandResponse{Error: ErrUserExists}

--- a/gen/templates/init/users/commands/update_role.go.tmpl
+++ b/gen/templates/init/users/commands/update_role.go.tmpl
@@ -69,11 +69,12 @@ func (h UpdateRoleHandler) Execute(ctx context.Context, c bus.Command) (res bus.
 		role = role.DropScopes().ApplyScopes(*cmd.Scopes...)
 	}
 
+	events := role.Commit()
 	err = h.roles.Persist(role)
 	switch err {
 	case nil:
 		res.ID = role.ID.String()
-		msgs = role.Release()
+		msgs = events
 		return
 	default:
 		res.Error = err

--- a/gen/templates/init/users/db/db_role_repository.go.tmpl
+++ b/gen/templates/init/users/db/db_role_repository.go.tmpl
@@ -14,6 +14,7 @@ func fromRole(role entities.Role) dbRole {
 		ID:     role.ID.String(),
 		Label:  role.Label,
 		Scopes: scopes,
+		Version: role.CurrentVersion(),
 	}
 }
 
@@ -31,6 +32,7 @@ func scopes(roles ...entities.Role) []dbScope {
 type dbRole struct {
 	ID    string `gorm:"primaryKey"`
 	Label string
+	Version int64
 
 	Scopes []dbScope `gorm:"many2many:role_scopes;joinForeignKey:role_id;joinReferences:scope_id"`
 }
@@ -47,6 +49,7 @@ func (r dbRole) Role() entities.Role {
 	for _, s := range r.Scopes {
 		role = role.ApplyScopes(s.Name)
 	}
+	role.ForceVersion(r.Version)
 	return role
 }
 

--- a/gen/templates/init/users/db/db_user_repository.go.tmpl
+++ b/gen/templates/init/users/db/db_user_repository.go.tmpl
@@ -35,6 +35,7 @@ func fromUser(u entities.User) dbUser {
 		LastSignedIn: last,
 		CreatedAt:    u.CreatedAt,
 		UpdatedAt:    u.UpdatedAt,
+		Version: u.CurrentVersion(),
 	}
 }
 
@@ -57,6 +58,7 @@ type dbUser struct {
 	LastSignedIn sql.NullTime
 	CreatedAt    time.Time
 	UpdatedAt    time.Time
+	Version		 int64
 }
 
 func (d dbUser) TableName() string {
@@ -76,7 +78,7 @@ func (d dbUser) User() entities.User {
 		time = nil
 	}
 
-	return entities.User{
+	u := entities.User{
 		ID:           d.ID,
 		Name:         d.Name,
 		Email:        email,
@@ -86,8 +88,10 @@ func (d dbUser) User() entities.User {
 		LastSignedIn: time,
 		CreatedAt:    d.CreatedAt,
 		UpdatedAt:    d.UpdatedAt,
-		EventQueue:   bus.NewEventQueue(d.ID),
+		EventBuffer:   bus.NewEventBuffer(d.ID),
 	}
+	u.ForceVersion(d.Version)
+	return u
 }
 
 func NewDBUserRepository(db *gorm.DB) *DBUserRepository {

--- a/gen/templates/init/users/entities/role.go.tmpl
+++ b/gen/templates/init/users/entities/role.go.tmpl
@@ -40,7 +40,7 @@ func BuildRole(ID string, Label string) Role {
 		ID:         i,
 		Label:      Label,
 		scopes:     make(map[string]Scope),
-		EventQueue: bus.NewEventQueue(i),
+		EventBuffer: bus.NewEventBuffer(i),
 	}
 	return r
 }
@@ -55,9 +55,9 @@ func CreateRole(label string) Role {
 		ID:         id,
 		Label:      label,
 		scopes:     make(map[string]Scope),
-		EventQueue: bus.NewEventQueue(id),
+		EventBuffer: bus.NewEventBuffer(id),
 	}
-	r.Publish(&RoleCreated{Payload: r})
+	r.Buffer(true, &RoleCreated{Payload: r})
 	return r
 }
 
@@ -68,7 +68,7 @@ type Role struct {
 
 	scopes map[string]Scope
 
-	bus.EventQueue `json:"-"`
+	bus.EventBuffer `json:"version"`
 }
 
 // Scopes returns the role's scopes
@@ -95,7 +95,7 @@ func (r Role) ApplyScopes(scopes ...string) Role {
 	for _, scope := range scopes {
 		s := Scope{scope}
 		r.scopes[scope] = s
-		r.Publish(&RoleScopeApplied{Payload: s})
+		r.Buffer(true, &RoleScopeApplied{Payload: s})
 	}
 	return r
 }

--- a/gen/templates/init/users/entities/role_test.go.tmpl
+++ b/gen/templates/init/users/entities/role_test.go.tmpl
@@ -13,7 +13,7 @@ func TestRole_Scopes(t *testing.T) {
 	assert.Contains(t, role.Scopes(), entities.Scope{"access:user"})
 	assert.Contains(t, role.Scopes(), entities.Scope{"payments:write"})
 	assert.NotContains(t, role.Scopes(), entities.Scope{"users:write"})
-	events := role.Release()
+	events := role.Commit()
 	assert.Len(t, events, 3)
 	created := events[0].(*entities.RoleCreated)
 	assert.Equal(t, "user", created.Owner)

--- a/gen/templates/init/users/entities/user_test.go.tmpl
+++ b/gen/templates/init/users/entities/user_test.go.tmpl
@@ -13,7 +13,7 @@ func TestRegister(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, user.Email.String(), "gabriel.carpreau@gmail.com")
-	events := user.Release()
+	events := user.Commit()
 	assert.Len(t, events, 1)
 	assert.IsType(t, &entities.UserCreated{}, events[0])
 	assert.Equal(t, user.ID.String(), events[0].(*entities.UserCreated).Owner)
@@ -64,14 +64,14 @@ func TestGetUserScopes(t *testing.T) {
 
 func TestGrantRole(t *testing.T) {
 	u, _ := entities.Register("gabriel@gmail.com", "password123")
-	u.Release()
+	u.Commit()
 	r := entities.CreateRole("Ambassador")
 
 	u = u.Grant(r)
 
 	assert.Len(t, u.RoleIDs, 1)
 	assert.Contains(t, u.RoleIDs, entities.NewRoleID("ambassador"))
-	events := u.Release()
+	events := u.Commit()
 	assert.Len(t, events, 1)
 	assert.IsType(t, &entities.UserGrantedRole{}, events[0])
 }
@@ -95,12 +95,12 @@ func TestRevokeAll(t *testing.T) {
 	admin := entities.CreateRole("Admin")
 	u = u.Grant(r).Grant(admin)
 	assert.Len(t, u.RoleIDs, 2)
-	u.Release()
+	u.Commit()
 
 	u = u.Revoke()
 
 	assert.Len(t, u.RoleIDs, 0)
-	events := u.Release()
+	events := u.Commit()
 	assert.Len(t, events, 1)
 	assert.IsType(t, &entities.UserRevokedAllRoles{}, events[0])
 	event := events[0].(*entities.UserRevokedAllRoles)
@@ -113,13 +113,13 @@ func TestRevokeOne(t *testing.T) {
 	admin := entities.CreateRole("Admin")
 	u = u.Grant(admin).Grant(r)
 	assert.Len(t, u.RoleIDs, 2)
-	u.Release()
+	u.Commit()
 
 	u = u.Revoke(admin)
 
 	assert.Len(t, u.RoleIDs, 1)
 	assert.True(t, u.RoleIDs[0].Equals(r.ID))
-	events := u.Release()
+	events := u.Commit()
 	assert.Len(t, events, 1)
 	assert.IsType(t, &entities.UserRevokedRole{}, events[0])
 }


### PR DESCRIPTION
Creates an event buffer, which stores events and manages entity versions.

Example of usage in `_example/users/entities/users.go`

Closes #5 